### PR TITLE
FPICK-281 Truncate status message to 255 characters

### DIFF
--- a/src/main/java/mn/foreman/api/model/CommandDone.java
+++ b/src/main/java/mn/foreman/api/model/CommandDone.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -44,6 +45,9 @@ public class CommandDone
     @Builder
     public static class Status {
 
+        /** Max length of message. */
+        private static final int MESSAGE_MAX_LENGTH = 255;
+
         /** A detailed message. */
         @JsonProperty("details")
         public String details;
@@ -55,5 +59,32 @@ public class CommandDone
         /** The type. */
         @JsonProperty("type")
         public DoneStatus type;
+
+        /**
+         * Sets the message with max size MESSAGE_MAX_LENGTH.
+         *
+         * @param message The message.
+         */
+        public void setMessage(final String message) {
+            this.message = StringUtils.truncate(message, MESSAGE_MAX_LENGTH);
+        }
+
+        /**
+         * Builder object for {@link Status}.
+         */
+        public static class StatusBuilder {
+
+            /**
+             * Sets message with a max length of MESSAGE_MAX_LENGTH.
+             *
+             * @param message The message to set.
+             *
+             * @return The builder.
+             */
+            public StatusBuilder message(final String message) {
+                this.message = StringUtils.truncate(message, MESSAGE_MAX_LENGTH);
+                return this;
+            }
+        }
     }
 }


### PR DESCRIPTION
The dashboard DB field is maxed at 255 as well as the amount of room in the command status dropdown in the UI