### PR TITLE
FPICK-445 Add feature flags to the pickaxe configuration

### DIFF
--- a/src/main/java/mn/foreman/api/endpoints/pickaxe/Pickaxe.java
+++ b/src/main/java/mn/foreman/api/endpoints/pickaxe/Pickaxe.java
@@ -450,6 +450,9 @@ public interface Pickaxe {
         /** The write socket timeout (units). */
         @JsonProperty("writeSocketTimeoutUnits")
         public String writeSocketTimeoutUnits;
+
+        @JsonProperty("featureFlags")
+        public Map<String, String> featureFlags;
     }
 
     /** A pickaxe instance. */


### PR DESCRIPTION
By adding feature flags to the pickaxe configuration we can roll out features slowly that we feel are more high risk

Related to https://github.com/foremanmining/foreman-apps/pull/513