### PR TITLE
OBM-185 Add configuration option for how many threads are used for finishing commands

### DIFF
--- a/src/main/java/mn/foreman/api/endpoints/pickaxe/Pickaxe.java
+++ b/src/main/java/mn/foreman/api/endpoints/pickaxe/Pickaxe.java
@@ -451,8 +451,13 @@ public interface Pickaxe {
         @JsonProperty("writeSocketTimeoutUnits")
         public String writeSocketTimeoutUnits;
 
+        /** Pickaxe feature flags. */
         @JsonProperty("featureFlags")
         public Map<String, String> featureFlags;
+
+        /** The number of threads to push command updates. */
+        @JsonProperty("commandFinishingThreadsOverride")
+        public Integer commandFinishingThreadsOverride;
     }
 
     /** A pickaxe instance. */


### PR DESCRIPTION
This change was made for https://github.com/foremanmining/foreman-apps/pull/540